### PR TITLE
Job file check for useSN

### DIFF
--- a/6.10-07_1717/Application_Files/code/main/jobFile.m
+++ b/6.10-07_1717/Application_Files/code/main/jobFile.m
@@ -98,6 +98,9 @@ classdef jobFile < handle
             if isempty(useSN) == 1.0
                 useSN = 0.0;
                 setappdata(0, 'useSN', 0.0)
+            elseif length(useSN) > 1.0
+                useSN = useSN(1.0);
+                setappdata(0, 'useSN', useSN)
             end
             
             if isempty(analysisGroups) == 1.0


### PR DESCRIPTION
If USE_SN is specified with more than one argument, only the first
argument is used.