### PR TITLE
Bug fixes

### DIFF
--- a/6.10-07_1717/Application_Files/bin/change_log.txt
+++ b/6.10-07_1717/Application_Files/bin/change_log.txt
@@ -34,3 +34,10 @@ FOR A COMPLETE LIST OF CHANGES, PLEASE CONTACT THE AUTHOR
 
 22APR17
 The FRF calculation now accounts for the value of RESIDUAL
+
+25APR17
+* Fixed a bug where the hotspot file would not be processed
+  [REGRESSION SINCE 6.10-05]
+
+* Hotspos are how written to the output directory instead of the input
+  directory

--- a/6.10-07_1717/Application_Files/code/main/analysis.m
+++ b/6.10-07_1717/Application_Files/code/main/analysis.m
@@ -6,7 +6,7 @@ classdef analysis < handle
 %   required to run this file.
 %   
 %   Quick Fatigue Tool 6.10-07 Copyright Louis Vallance 2017
-%   Last modified 15-Apr-2017 19:34:54 GMT
+%   Last modified 25-Apr-2017 12:13:25 GMT
     
     %%
     
@@ -732,24 +732,29 @@ classdef analysis < handle
             % Get the corrected stress amplitudes
             switch msCorrection
                 case 1.0 % Morrow
+                    Sf = getappdata(0, 'Sf');
+                    
                     if getappdata(0, 'useSN') == 0.0 && getappdata(0, 'algorithm') ~= 7.0
-                        morrowSf = getappdata(0, 'Sf') - Sm;
+                        morrowSf = Sf - Sm;
                         
                         % Check for negative values
                         for i = 1:length(Sm)
-                            if morrowSf(i) <= 0.0
+                            if morrowSf(i) < 0.0
                                 morrowSf(i) = 1e-06;
+                                
+                                % Warn the user
+                                messenger.writeMessage(257.0)
                             end
                         end
                         setappdata(0, 'morrowSf', morrowSf)
                         mscCycles = cycles;
                     else
-                        mscCycles = cycles.*((1.0 - ((Sm')./(getappdata(0, 'Sf')))).^-1.0);
+                        mscCycles = cycles.*((1.0 - ((Sm')./(Sf))).^-1.0);
                         
                         % Check for negative values
                         for i = 1:length(Sm)
-                            if mscCycles(i) <= 0.0
-                                mscCycles(i) = 1e-06;
+                            if mscCycles(i) < 0.0
+                                mscCycles(i) = Sf;
                                 
                                 % Warn the user
                                 messenger.writeMessage(159.0)

--- a/6.10-07_1717/Application_Files/code/main/cleanup.m
+++ b/6.10-07_1717/Application_Files/code/main/cleanup.m
@@ -6,7 +6,7 @@ function [] = cleanup(status)
 %   is not required to run this file.
 %   
 %   Quick Fatigue Tool 6.10-07 Copyright Louis Vallance 2017
-%   Last modified 24-Apr-2017 18:27:33 GMT
+%   Last modified 25-Apr-2017 12:13:25 GMT
     
     %%
     
@@ -65,7 +65,7 @@ if status == 1.0
     % Write file header
     fprintf(fid, 'Quick Fatigue Tool 6.10-07\r\n');
     fprintf(fid, '(Copyright Louis Vallance 2017)\r\n');
-    fprintf(fid, 'Last modified 24-Apr-2017 18:27:33 GMT\r\n\r\n');
+    fprintf(fid, 'Last modified 25-Apr-2017 12:13:25 GMT\r\n\r\n');
     
     % Continue writing the file
     fprintf(fid, 'THE ANALYSIS WAS ABORTED FOR THE FOLLOWING REASON(S):');
@@ -165,7 +165,7 @@ if status == 1.0
         rmappdata(0, 'E036')
     end
     if getappdata(0, 'E037') == 1.0
-        fprintf(fid, '\r\n\r\n***ERROR: Multiple load histories are not permitted for Uniaxial Stress-Life');
+        fprintf(fid, '\r\n\r\n***ERROR: Multiple load histories are not permitted for Uniaxial Stress-Life analysis');
         fprintf(fid, '\r\n\r\nError code: E037');
         rmappdata(0, 'E037')
     end

--- a/6.10-07_1717/Application_Files/code/main/jobFile.m
+++ b/6.10-07_1717/Application_Files/code/main/jobFile.m
@@ -6,7 +6,7 @@ classdef jobFile < handle
 %   required to run this file.
 %   
 %   Quick Fatigue Tool 6.10-07 Copyright Louis Vallance 2017
-%   Last modified 24-Apr-2017 18:27:33 GMT
+%   Last modified 25-Apr-2017 12:13:25 GMT
     
     %%
     
@@ -107,7 +107,7 @@ classdef jobFile < handle
                 setappdata(0, 'analysisGroups', 'DEFAULT')
             end
             
-            if (isempty(items) == 1.0) || ((ischar(items) == 1.0) && (strcmpi(items, 'ALL') == 0.0) && strcmpi(items, 'PEEK') == 0.0)
+            if (isempty(items) == 1.0) || ((ischar(items) == 1.0) && (strcmpi(items, 'ALL') == 0.0) && strcmpi(items, 'PEEK') == 0.0 && exist(items, 'file') == 0.0)
                 items = 'ALL';
                 setappdata(0, 'items', 'ALL')
             end

--- a/6.10-07_1717/Application_Files/code/main/main.m
+++ b/6.10-07_1717/Application_Files/code/main/main.m
@@ -11,7 +11,7 @@ function [] = main(flags)
 %   Author contact: louisvallance@hotmail.co.uk
 %
 %   Quick Fatigue Tool 6.10-07 Copyright Louis Vallance 2017
-%   Last modified 24-Apr-2017 18:27:33 GMT
+%   Last modified 25-Apr-2017 12:13:25 GMT
 
 % Begin main code - DO NOT EDIT
 format long;    clc;    warning('off', 'all')
@@ -48,7 +48,7 @@ setappdata(0, 'messageFileWarnings', 0.0)
 %% PRINT COMMAND WINDOW HEADER
 fprintf('[NOTICE] Quick Fatigue Tool 6.10-07')
 fprintf('\n[NOTICE] (Copyright Louis Vallance 2017)')
-fprintf('\n[NOTICE] Last modified 24-Apr-2017 18:27:33 GMT')
+fprintf('\n[NOTICE] Last modified 25-Apr-2017 12:13:25 GMT')
 
 cleanExit = 0.0;
 

--- a/6.10-07_1717/Application_Files/code/main/messenger.m
+++ b/6.10-07_1717/Application_Files/code/main/messenger.m
@@ -7,7 +7,7 @@ classdef messenger < handle
 %   required to run this file.
 %   
 %   Quick Fatigue Tool 6.10-07 Copyright Louis Vallance 2017
-%   Last modified 12-Apr-2017 12:25:20 GMT
+%   Last modified 25-Apr-2017 12:13:25 GMT
     
     %%
     
@@ -1364,9 +1364,10 @@ classdef messenger < handle
                         setappdata(0, 'messageFileWarnings', 1.0)
                     case 159.0
                         if getappdata(0, 'suppress_ID159') == 0.0
-                            fprintf(fidType(i), [returnType{i}, '***WARNING: Asymptotic values were calculated by the Morrow mean stress correction', returnType{i}]);
-                            fprintf(fidType(i), ['-> Damage at these items will be assumed as 1e-06', returnType{i}]);
-                            fprintf(fidType(i), ['-> Check the loading for potential non-fatigue conditions and consider using a different mean stress correction', returnType{i}]);
+                            fprintf(fidType(i), [returnType{i}, '***WARNING: After applying the Morrow mean stress correction, some cycles are negative', returnType{i}]);
+                            fprintf(fidType(i), ['-> The Morrow mean stress correction is not defined for mean stress at or above the fatigue strength coefficient (Sf'')', returnType{i}]);
+                            fprintf(fidType(i), ['-> Non-fatigue failure will be assumed at the affected analysis items', returnType{i}]);
+                            fprintf(fidType(i), ['-> Check the validity of the loading', returnType{i}]);
                             
                             if i == X
                                 setappdata(0, 'suppress_ID159', 1.0)
@@ -1994,6 +1995,19 @@ classdef messenger < handle
                             fprintf(fidType(i), ['-> Modification of the fatigue limit is enabled with the environment variable ''modifyEnduranceLimit''. Therefore, the fatigue limit may be reduced during the analysis, causing unexpected behaviour', returnType{i}]);
                             fprintf(fidType(i), ['-> Consult Section 7.8 of the Quick Fatigue Tool User Guide for additional guidance on this message', returnType{i}]);
                         end
+                    case 257.0
+                        if getappdata(0, 'suppress_ID257') == 0.0
+                            fprintf(fidType(i), [returnType{i}, '***WARNING: After applying the Morrow mean stress correction, the corrected fatigue strength coefficient (Sf'') is negative', returnType{i}]);
+                            fprintf(fidType(i), ['-> The Morrow mean stress correction is not defined for mean stress at or above the fatigue strength coefficient (Sf'')', returnType{i}]);
+                            fprintf(fidType(i), ['-> Non-fatigue failure will be assumed at the affected analysis items', returnType{i}]);
+                            fprintf(fidType(i), ['-> Check the validity of the loading', returnType{i}]);
+                            
+                            if i == X
+                                setappdata(0, 'suppress_ID257', 1.0)
+                            end
+                            
+                            setappdata(0, 'messageFileWarnings', 1.0)
+                        end
                 end
             end
         end
@@ -2020,6 +2034,7 @@ classdef messenger < handle
             setappdata(0, 'suppress_ID190', 0.0)
             setappdata(0, 'suppress_ID205', 0.0)
             setappdata(0, 'suppress_ID220', 0.0)
+            setappdata(0, 'suppress_ID257', 0.0)
         end
         
         %% WRITE LOG FILE

--- a/6.10-07_1717/Application_Files/code/main/postProcess.m
+++ b/6.10-07_1717/Application_Files/code/main/postProcess.m
@@ -1643,8 +1643,15 @@ classdef postProcess < handle
             % Concatenate data
             data = [hotspots; mainID(hotspots)'; subID(hotspots)'; nodalLife(hotspots)]';
             
+            % Check that the directory exists
+            root = getappdata(0, 'outputDirectory');
+            
+            if exist(sprintf('%s/Data Files', root), 'dir') == 0.0
+                mkdir(sprintf('%s/Data Files', root))
+            end
+            
             % Create the file
-            dir = ['Project/input/', sprintf('hotspots_%s.dat', jobName)];
+            dir = [pwd, sprintf('\\Project\\output\\%s\\Data Files\\', jobName), 'hotspots.dat'];
             fid = fopen(dir, 'w+');
             
             fprintf(fid, 'HOTSPOTS\r\n');

--- a/6.10-07_1717/Application_Files/code/material_manager/UserMaterial.m
+++ b/6.10-07_1717/Application_Files/code/material_manager/UserMaterial.m
@@ -1477,7 +1477,7 @@ catch
     % Don't tighten the axis
 end
 
-xlabel('Life (Nf)', 'FontSize', 16);    ylabel('Stress Amplitude (MPa)', 'FontSize', 16)
+xlabel('Cycles (Nf)', 'FontSize', 16);    ylabel('Stress Amplitude (MPa)', 'FontSize', 16)
 string = sprintf('S-N Data for %s', get(handles.edit_name, 'string'));
 title(string, 'FontSize', 18);   grid on
 

--- a/6.10-07_1717/Documentation/README.txt
+++ b/6.10-07_1717/Documentation/README.txt
@@ -301,4 +301,4 @@ Quick Fatigue Tool User Guide.
 %   louisvallance@hotmail.co.uk
 %
 %   Quick Fatigue Tool 6.10-07 Copyright Louis Vallance 2017
-%   Last modified 19-Apr-2017 14:29:55 GMT
+%   Last modified 25-Apr-2017 12:13:25 GMT


### PR DESCRIPTION
- Fixed a bug where the hotspos file would not be processed after 6.10.5

- The hotspot file is now written to the output directory instead of the
input directory

- Fixed a bug where the message about negative cycles from the Morrow
mean stress correction would not always be printed to the .msg file.
Also improved the grammar of the message